### PR TITLE
Add support of KWARGS specified by annotation

### DIFF
--- a/jrobot-karaf/src/test/robotframework/acceptance/020_jrobot_tests.robot
+++ b/jrobot-karaf/src/test/robotframework/acceptance/020_jrobot_tests.robot
@@ -36,6 +36,17 @@ Library Numeric Type KWARGS Test
     ${sum}    BaseLib.Sub    5   b=1
     Should Be Equal As Integers    4    ${sum}
 
+Library Numeric Type KWARGS Override Test
+    [Documentation]    Tests if Keyword KWARGS works properly if specified by Annotation
+    ${sum}    ArgumentsLib.Sub    5.2    element_2=1.3
+    Should be equal as numbers    3.9    ${sum}
+    ${sum}    ArgumentsLib.Sub    element_2=5.2    element_1=1.3
+    Should be equal as numbers    -3.9    ${sum}
+    ${sum}    ArgumentsLib.Sub    element_2=5   element_1=1
+    Should Be Equal As Integers    -4    ${sum}
+    ${sum}    ArgumentsLib.Sub    5   element_2=1
+    Should Be Equal As Integers    4    ${sum}
+
 Library Inheritance Test
     [Documentation]    Tests if Class inheritance of keywordds works properly
     ${name_1}    BaseLib.Get Name
@@ -58,6 +69,7 @@ Setup Suite
     Verify Bundle Started On Karaf    jrobot-test-library
     Import Library    Remote    http://localhost:8270/BaseLibrary    WITH NAME    BaseLib
     Import Library    Remote    http://localhost:8270/ExtendedLibrary    WITH NAME    ExtendedLib
+    Import Library    Remote    http://localhost:8270/ArgumentsLibrary    WITH NAME    ArgumentsLib
 
 Clean Suite
     [Documentation]    Cleans Suites resources

--- a/jrobot-remote-server/src/main/java/org/robotframework/remoteserver/keywords/CheckedKeywordImpl.java
+++ b/jrobot-remote-server/src/main/java/org/robotframework/remoteserver/keywords/CheckedKeywordImpl.java
@@ -18,6 +18,7 @@
 package org.robotframework.remoteserver.keywords;
 
 import java.lang.reflect.Method;
+import org.robotframework.javalib.annotation.ArgumentNames;
 import org.robotframework.javalib.reflection.ArgumentConverter;
 import org.robotframework.javalib.reflection.ArgumentGrouper;
 import org.robotframework.javalib.reflection.IArgumentConverter;
@@ -82,6 +83,9 @@ public class CheckedKeywordImpl implements CheckedKeyword {
     }
 
     @Override public String[] getArgumentNames() {
+        if (method.isAnnotationPresent(ArgumentNames.class)) {
+            return method.getAnnotation(ArgumentNames.class).value();
+        }
         String[] names = new String[method.getParameterCount()];
         for (int i = 0; i < method.getParameters().length; i++) {
             names[i] = method.getParameters()[i].getName();

--- a/jrobot-remote-server/src/main/java/org/robotframework/remoteserver/keywords/OverloadedKeywordExtractor.java
+++ b/jrobot-remote-server/src/main/java/org/robotframework/remoteserver/keywords/OverloadedKeywordExtractor.java
@@ -27,8 +27,6 @@ import java.util.Set;
 import java.util.stream.Stream;
 import org.robotframework.javalib.annotation.RobotKeyword;
 import org.robotframework.javalib.annotation.RobotKeywordOverload;
-import org.robotframework.javalib.util.IKeywordNameNormalizer;
-import org.robotframework.javalib.util.KeywordNameNormalizer;
 import org.robotframework.remoteserver.library.RemoteLibrary;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,19 +58,13 @@ public class OverloadedKeywordExtractor implements KeywordExtractor<OverloadedKe
 
     @Override public Map<String, OverloadedKeyword> extractKeywords(final RemoteLibrary keywordBean) {
         Objects.requireNonNull(keywordBean);
-        LOG.warn("Extracting {}", keywordBean.getURI());
-        IKeywordNameNormalizer keywordNameNormalizer = new KeywordNameNormalizer();
         final Map<String, OverloadedKeyword> overloadableKeywords = new HashMap<>();
         final Set<String> interfaceKeywords = new HashSet<>(), interfaceKeywordsOverload = new HashSet<>();
         getMethods(keywordBean.getClass()).forEach(method -> {
             if (method.isAnnotationPresent(RobotKeyword.class)) {
                 interfaceKeywords.add(method.getName());
-                LOG.warn("{} Detected Keyword  {}", method.getName(),
-                        keywordNameNormalizer.normalize(method.getName()));
             } else if (method.isAnnotationPresent(RobotKeywordOverload.class)) {
                 interfaceKeywordsOverload.add(method.getName());
-                LOG.warn("{} Detected KeywordOverload  {}", method.getName(),
-                        keywordNameNormalizer.normalize(method.getName()));
             }
         });
         Arrays.stream(keywordBean.getClass().getMethods())

--- a/jrobot-test-library/src/main/java/org/robotframework/test/ArgumentsLibrary.java
+++ b/jrobot-test-library/src/main/java/org/robotframework/test/ArgumentsLibrary.java
@@ -1,0 +1,28 @@
+package org.robotframework.test;
+
+import org.robotframework.javalib.annotation.ArgumentNames;
+import org.robotframework.javalib.annotation.RobotKeywords;
+import org.robotframework.remoteserver.RemoteServer;
+
+@RobotKeywords public class ArgumentsLibrary extends BaseLibrary {
+
+    public ArgumentsLibrary(RemoteServer server) {
+        super(server);
+    }
+
+    @Override @ArgumentNames({"element_1", "element_2"}) public double add(double a, double b) {
+        return super.add(a, b);
+    }
+
+    @Override @ArgumentNames({"element_1", "element_2"}) public int add(int a, int b) {
+        return super.add(a, b);
+    }
+
+    @Override @ArgumentNames({"element_1", "element_2"}) public double sub(double a, double b) {
+        return super.sub(a, b);
+    }
+
+    @Override @ArgumentNames({"element_1", "element_2"}) public int sub(int a, int b) {
+        return super.sub(a, b);
+    }
+}

--- a/jrobot-test-library/src/main/resources/OSGI-INF/blueprint/jrobot-test-library.xml
+++ b/jrobot-test-library/src/main/resources/OSGI-INF/blueprint/jrobot-test-library.xml
@@ -8,8 +8,12 @@
     <bean id="test-library" class="org.robotframework.test.ExtendedLibrary">
         <argument ref="robot-remote-server"/>
     </bean>
+    <bean id="test-library-arguments" class="org.robotframework.test.ArgumentsLibrary">
+        <argument ref="robot-remote-server"/>
+    </bean>
     <!-- Services -->
     <service ref="test-library" interface="org.robotframework.test.TestLibraryService"/>
+    <service ref="test-library-arguments" interface="org.robotframework.remoteserver.library.RemoteLibrary"/>
     <service ref="test-library-parent" interface="org.robotframework.remoteserver.library.RemoteLibrary"/>
 </blueprint>
 


### PR DESCRIPTION
If Arguments annotations is specified beside keyword its values will be
used for KWARGS matching.
Removed unnecessary warn logs, updated acceptance tests with test
of Argument annotation fucnctionality.

Signed-off-by: Martin Mihálek <aenniw@gmail.com>