### PR TITLE
Keyword order matching

### DIFF
--- a/jrobot-karaf/src/test/robotframework/acceptance/020_jrobot_tests.robot
+++ b/jrobot-karaf/src/test/robotframework/acceptance/020_jrobot_tests.robot
@@ -108,11 +108,16 @@ Library Confict resolving
     Should Be Equal As Strings    ${resp}    [nine five one],[951]
     ${resp}    ConflictLib.Conflict Overloaded Method    nine five one    951    false
     Should Be Equal As Strings    ${resp}    [nine five one],[951],[false]
+    ${resp}    ConflictLib.Original Keyword    2.5
+    Should Be Equal As Strings    ${resp}    Double 2.5
+    ${resp}    ConflictLib.Original Keyword    10    9
+    Should Be Equal As Strings    ${resp}    Ints 10 9
 
 *** Keywords ***
 Setup Suite
     [Documentation]    Initialize Suite resources
     Start Karaf
+    Run On Karaf    log:set DEBUG org.robotframework.remoteserver
     Verify Feature Installed On Karaf    jrobot-remote-server
     Verify Feature Started On Karaf    jrobot-remote-server
     Install Bundle On Karaf    mvn:com.github.aenniw/jrobot-test-library

--- a/jrobot-remote-server/src/main/java/org/robotframework/remoteserver/keywords/CheckedKeyword.java
+++ b/jrobot-remote-server/src/main/java/org/robotframework/remoteserver/keywords/CheckedKeyword.java
@@ -12,8 +12,15 @@ public interface CheckedKeyword extends DocumentedKeyword, TaggedKeyword {
      * Checks if {@link org.robotframework.javalib.keyword.Keyword} is capable of execution with provided arguments
      *
      * @param args Arguments that will be used in {@link org.robotframework.javalib.keyword.Keyword} execution
-     * @return If {@link org.robotframework.javalib.keyword.Keyword} compatibile with arguments
+     * @return If {@link org.robotframework.javalib.keyword.Keyword} compatible with arguments
      */
     boolean canExecute(Object[] args);
+
+    /**
+     * Returns argument types used in current {@link org.robotframework.javalib.keyword.Keyword}
+     *
+     * @return Arrays containing ordered {@link Class} of each argument
+     */
+    Class<?>[] getArguments();
 
 }

--- a/jrobot-remote-server/src/main/java/org/robotframework/remoteserver/keywords/CheckedKeywordImpl.java
+++ b/jrobot-remote-server/src/main/java/org/robotframework/remoteserver/keywords/CheckedKeywordImpl.java
@@ -81,6 +81,10 @@ public class CheckedKeywordImpl implements CheckedKeyword {
         }
     }
 
+    @Override public Class<?>[] getArguments() {
+        return method.getParameterTypes();
+    }
+
     @Override public String[] getTags() {
         KeywordTags tags = method.getAnnotation(KeywordTags.class);
         if (Objects.nonNull(tags) && tags.value().length > 0) {

--- a/jrobot-remote-server/src/main/java/org/robotframework/remoteserver/keywords/OverloadedKeywordImpl.java
+++ b/jrobot-remote-server/src/main/java/org/robotframework/remoteserver/keywords/OverloadedKeywordImpl.java
@@ -53,8 +53,20 @@ public class OverloadedKeywordImpl implements OverloadedKeyword {
      * @param method       {@link Method} providing execution routine
      */
     public OverloadedKeywordImpl(Object keywordClass, Method method) {
-        this.keywordName = method.getName();
-        this.keywordClass = keywordClass;
+        this(keywordClass, method, method.getName());
+    }
+
+    /**
+     * Constructor creating {@link OverloadedKeyword} providing {@link Object} and {@link Method},
+     * that are associated together
+     *
+     * @param keywordClass {@link Object} instance used for execution of {@link Method}
+     * @param method       {@link Method} providing execution routine
+     * @param name         Name of current {@link OverloadedKeyword}
+     */
+    public OverloadedKeywordImpl(Object keywordClass, Method method, String name) {
+        this.keywordName = Objects.requireNonNull(name);
+        this.keywordClass = Objects.requireNonNull(keywordClass);
         addOverload(method);
     }
 

--- a/jrobot-test-library/src/main/java/org/robotframework/test/ConflictLibrary.java
+++ b/jrobot-test-library/src/main/java/org/robotframework/test/ConflictLibrary.java
@@ -39,4 +39,12 @@ import org.robotframework.remoteserver.library.AbstractClassLibrary;
         return "[" + s + "],[" + a + "],[" + b + "]";
     }
 
+    @RobotKeywordOverload public String originalKeyword(double d) {
+        return "Double " + d;
+    }
+
+    @RobotKeyword("Original Keyword") public String alternative(int a, int b) {
+        return "Ints " + a + " " + b;
+    }
+
 }


### PR DESCRIPTION
- Adds support fot Keyword anotation to override keyword name from method definition.
- Adds ordering of methods in Keyword when working with overloaded keywords, so that
best match execution can be achieved and make execution of overloaded keywords deterministic

Currenly only very simple keyword ranking is implemented based on String count in keyword arguments.
It is needed to add more complex ranking instead of current one, but for main cases this should be enought.